### PR TITLE
Explicit relative imports

### DIFF
--- a/python/segmnist/__init__.py
+++ b/python/segmnist/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ['mnist', 'caffe']
 
-from segmnist import SegMNIST
-from segmnistshapes import SegMNISTShapes
+from .segmnist import SegMNIST
+from .segmnistshapes import SegMNISTShapes

--- a/python/segmnist/loader/__init__.py
+++ b/python/segmnist/loader/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ['mnist', 'shuffled_mnist']
 
-from mnist import MNIST
-from shuffled_mnist import ShuffledMNIST
+from .mnist import MNIST
+from .shuffled_mnist import ShuffledMNIST

--- a/python/segmnist/pytorch/__init__.py
+++ b/python/segmnist/pytorch/__init__.py
@@ -1,0 +1,1 @@
+from segmnist_pytorch import SegMNISTShapesPyTorch

--- a/python/segmnist/pytorch/__init__.py
+++ b/python/segmnist/pytorch/__init__.py
@@ -1,1 +1,1 @@
-from segmnist_pytorch import SegMNISTShapesPyTorch
+from .segmnist_pytorch import SegMNISTShapesPyTorch

--- a/python/segmnist/pytorch/segmnist_pytorch.py
+++ b/python/segmnist/pytorch/segmnist_pytorch.py
@@ -1,0 +1,99 @@
+import torch
+
+from segmnist import SegMNIST
+from segmnist import SegMNISTShapes
+from segmnist.segmnistshapes import SquareGenerator
+from segmnist.segmnistshapes import RectangleGenerator
+from segmnist.texture_generator import random_color_texture
+
+
+class SegMNISTShapesPyTorch():
+    """
+    SegMNIST Shapes <https://github.com/williford/seg-mnist-dataset> Dataset.
+
+    Args:
+        batch_size (int): Batch size
+        nclasses (int): Number of classes (e.g. 12 for 10 digits plus
+            squares and rectangles)
+        im_shape (tuple): depth, height, width
+        mnist_dataset (string): mnist-training or mnist-validation
+        bg_pix_mul (float): multiplier for number of background pixels
+            that are not masked
+        digit_positioning (string): TODO
+    """
+
+    def __init__(self, batch_size, nclasses, im_shape, mnist_dataset,
+                 bg_pix_mul=1.0, digit_positioning='random', max_digits=None,
+                 min_digits=None, scale_range=(0.5, 1.5), GPU=False):
+        self.batch_size = batch_size
+        self.nclasses = nclasses
+        self.imshape = im_shape
+        self.mnist_dataset_name = mnist_dataset
+        self.bg_pix_mul = bg_pix_mul
+        self.positioning = digit_positioning
+        self.GPU = GPU
+
+        self.mnist = SegMNIST.load_standard_MNIST(
+            self.mnist_dataset_name,
+            shuffle=True
+        )
+
+        shapes = []
+        if self.nclasses >= 11:
+            shapes.append(SquareGenerator(random_color_texture))
+        if self.nclasses >= 12:
+            shapes.append(RectangleGenerator(random_color_texture))
+
+        self.batch_loader = SegMNISTShapes(
+            self.mnist,
+            imshape=self.imshape,
+            bg_pix_mul=self.bg_pix_mul,
+            positioning=self.positioning,
+            shapes=shapes
+        )
+
+        if max_digits:
+            self.batch_loader.set_max_digits(max_digits)
+
+        if min_digits:
+            self.batch_loader.set_min_digits(min_digits)
+
+        self.batch_loader.set_scale_range(scale_range)
+
+        print_info("SegMNISTShapesLayerSync",
+                   mnist_dataset,
+                   batch_size,
+                   im_shape)
+
+    def get_batch(self, cuda_device=0):
+        """
+        Creates a batch. Returns torch tensors
+
+        Args:
+            cuda_device (int): CUDA device number
+        """
+        (img_data, cls_label, seg_label) = (
+            self.batch_loader.create_batch(self.batch_size))
+
+        # convert to tensor
+        (img_data, cls_label, seg_label) = (
+            torch.from_numpy(img_data).type(torch.FloatTensor),
+            torch.from_numpy(cls_label).type(torch.LongTensor),
+            torch.from_numpy(seg_label).type(torch.FloatTensor))
+
+        # transfer to GPU
+        if self.GPU:
+            (img_data, cls_label, seg_label) = (
+                img_data.cuda(cuda_device),
+                cls_label.cuda(cuda_device),
+                seg_label.cuda(cuda_device))
+
+        return (img_data, cls_label, seg_label)
+
+
+def print_info(name, mnist_dataset, batch_size, im_shape):
+    """
+    Output some info regarding the class
+    """
+    print("{} initialized for dataset: {}, with bs: {}, im_shape: {}.".format(
+        name, mnist_dataset, batch_size, im_shape))

--- a/python/segmnist/pytorch/segmnist_pytorch.py
+++ b/python/segmnist/pytorch/segmnist_pytorch.py
@@ -78,8 +78,11 @@ class SegMNISTShapesPyTorch():
         # convert to tensor
         (img_data, cls_label, seg_label) = (
             torch.from_numpy(img_data).type(torch.FloatTensor),
-            torch.from_numpy(cls_label).type(torch.LongTensor),
+            torch.from_numpy(cls_label).type(torch.FloatTensor),
             torch.from_numpy(seg_label).type(torch.FloatTensor))
+
+        # flatten cls_label
+        cls_label = cls_label.view(-1, self.nclasses)
 
         # transfer to GPU
         if self.GPU:

--- a/python/segmnist/segmnistshapes.py
+++ b/python/segmnist/segmnistshapes.py
@@ -1,7 +1,7 @@
 import random
 import itertools
 from . import loader
-from texture_generator import random_color_texture
+from .texture_generator import random_color_texture
 from . import mnist_generator
 import os
 import numpy as np

--- a/python/segmnist/static_segmnistshapes.py
+++ b/python/segmnist/static_segmnistshapes.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os
-import loader
 import scipy.misc
 import numpy as np
 import errno
@@ -13,6 +12,7 @@ import pdb
 import h5py
 from segmnist import SegMNIST
 from segmnistshapes import SegMNISTShapes
+from . import loader
 
 
 def mkdirs(path):

--- a/python/segmnist/texture_generator.py
+++ b/python/segmnist/texture_generator.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-
 import os
-import loader
 import scipy.misc
 import numpy as np
 import errno
@@ -11,6 +8,8 @@ import itertools
 import h5py
 import math
 import random
+
+from . import loader
 
 
 def random_color_texture(shape, mean, var):


### PR DESCRIPTION
The code was original written when python allowed implicit relative imports. If you use it with a modern python version (starting in Python3?), the current code requires adding all the segmnist directories to the PATH. The following PR should make this unnecessary. I tried to test the code, but I was getting the error "TypeError: get_batch() got an unexpected keyword argument 'attend'".